### PR TITLE
Improve test reliability by resetting parameters

### DIFF
--- a/nikamap/tests/test_nikamap.py
+++ b/nikamap/tests/test_nikamap.py
@@ -434,7 +434,7 @@ def wobble_grid_sources():
     return nm
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def generate_fits(tmpdir_factory):
 
     tmpdir = tmpdir_factory.mktemp("nm_map")


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_nikamap_write` by cleaning the state before running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 nikamap/tests/test_nikamap.py::test_nikamap_write`.
```
        outfilename = filename.replace("map.fits", "map2.fits")
>       data.write(outfilename)
...
>               raise OSError(f"File {self.name!r} already exists.")
E               OSError: File '/tmp/pytest-of-rtp1/pytest-28/nm_map0/map2.fits' already **exists.**
```
More specifically, this PR cleans the pre-state by re-initialize the parameters for each test function. In this way, the test does not fail on the second run any more.

It may be better to avoid state pollutions so that some other tests won't fail in the future due to the shared state pollution.
